### PR TITLE
fix: resolve Firefox Xray vision permission error when accessing event properties

### DIFF
--- a/bus.ts
+++ b/bus.ts
@@ -25,10 +25,11 @@ export const on_request_from_server: OnRequestFromServer = (
     // Parse the JSON string to get the actual event object
     let event: any;
     try {
-      const jsonString = typeof emitter_data.detail === 'string' 
-        ? emitter_data.detail 
-        : JSON.stringify(emitter_data.detail); // Fallback for non-string (shouldn't happen)
-      event = JSON.parse(jsonString);
+      if (typeof emitter_data.detail !== 'string') {
+        console.error(`[bus] Expected event detail to be a string, but got:`, emitter_data.detail);
+        return;
+      }
+      event = JSON.parse(emitter_data.detail);
     } catch (e: any) {
       console.error(`[bus] Failed to parse event data:`, e);
       return;

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -20,7 +20,7 @@ export default defineContentScript({
     // Inject script as external file to avoid CSP violations
     // Create script tag with src pointing to web-accessible resource
     // This loads as external file, satisfying CSP requirements
-    const scriptUrl = browser.runtime.getURL("main_world.js");
+    const scriptUrl = browser.runtime.getURL("/main_world.js");
     
     // Check if script is already injected to avoid duplicates
     const existingScript = document.querySelector(`script[src="${scriptUrl}"]`);

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -28,6 +28,8 @@ export default defineContentScript({
       const script = document.createElement("script");
       script.src = scriptUrl;
       script.type = "module";
+      // Remove the script element after it loads to avoid memory leaks
+      script.onload = () => script.remove();
       // Inject into main world by appending to page's document
       (document.head || document.documentElement).appendChild(script);
     }
@@ -63,8 +65,8 @@ export default defineContentScript({
           message,
         );
       }
-      // Clone the reply to ensure it can be serialized properly
-      const clonedReply = structuredClone(reply);
+      // Serialize and deserialize the reply to ensure it is JSON-safe and avoid Xray issues
+      const clonedReply = JSON.parse(JSON.stringify(reply));
       sendToWebSocket(clonedReply);
     });
   },

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -10,14 +10,27 @@ function sendToWebSocket(data: any) {
 
 // Content script is now registered dynamically via background.ts
 // The matches are configured by users in the options page
+// Note: Firefox requires at least one match pattern in manifest, so we provide a default
+// The dynamic registration will override this with user-configured patterns
 export default defineContentScript({
-  // Note: matches will be empty here since we're using dynamic registration
-  matches: [],
+  matches: ["*://app.diagrams.net/*"],
   async main() {
     console.log("Hello content " + Date.now(), { window, browser });
-    await injectScript("/main_world.js", {
-      keepInDom: true,
-    });
+    
+    // Inject script as external file to avoid CSP violations
+    // Create script tag with src pointing to web-accessible resource
+    // This loads as external file, satisfying CSP requirements
+    const scriptUrl = browser.runtime.getURL("main_world.js");
+    
+    // Check if script is already injected to avoid duplicates
+    const existingScript = document.querySelector(`script[src="${scriptUrl}"]`);
+    if (!existingScript) {
+      const script = document.createElement("script");
+      script.src = scriptUrl;
+      script.type = "module";
+      // Inject into main world by appending to page's document
+      (document.head || document.documentElement).appendChild(script);
+    }
 
     // Listen for messages from background
     browser.runtime.onMessage.addListener((message) => {
@@ -26,8 +39,12 @@ export default defineContentScript({
           "[content] Received from background from WebSocket:",
           message.data,
         );
+        // Serialize to JSON string to avoid Firefox Xray vision blocking property access
+        // When CustomEvent.detail crosses context boundaries, Firefox wraps it with Xray
+        // By passing a JSON string, we avoid any property access on Xray-wrapped objects
+        const jsonData = JSON.stringify(message.data);
         window.dispatchEvent(
-          new CustomEvent(bus_request_stream, { detail: message.data }),
+          new CustomEvent(bus_request_stream, { detail: jsonData }),
         );
       } else if (message.type === "WS_STATUS") {
         console.log(
@@ -46,7 +63,9 @@ export default defineContentScript({
           message,
         );
       }
-      sendToWebSocket(reply);
+      // Clone the reply to ensure it can be serialized properly
+      const clonedReply = structuredClone(reply);
+      sendToWebSocket(clonedReply);
     });
   },
 });

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   "author": "Ladislav Gazo",
   "license": "MIT",
   "packageManager": "pnpm@10.8.1",
+  "engines": {
+    "node": ">=23.0.0"
+  },
   "dependencies": {
     "react": "19.1.0",
     "react-dom": "19.1.0"


### PR DESCRIPTION
## Problem

Firefox's Xray vision security model blocks property access on objects that cross context boundaries (content script → main world). This caused `Permission denied to access property '__event'` errors when trying to access properties on `CustomEvent.detail` objects passed from the content script to the main world.

### Error Details
```
Uncaught Error: Permission denied to access property "__event"
    at main_world.js:1:33326
```

This occurred when the extension tried to access `event.__event` in `bus.ts` after receiving a CustomEvent from the content script.

## Solution

The fix serializes data as a JSON string in the content script before passing it via CustomEvent, then parses the JSON string in the main world to get the event object. This avoids accessing properties on Xray-wrapped objects since strings are not wrapped by Firefox's security model.

### Changes Made

1. **`entrypoints/content.ts`**:
   - Changed from passing `message.data` directly to serializing it as JSON string: `JSON.stringify(message.data)`
   - Pass the JSON string as `CustomEvent.detail` instead of the object

2. **`bus.ts`**:
   - Parse the JSON string from `emitter_data.detail` to get the event object
   - Added error handling for JSON parsing failures
   - Extract `request.__request_id` early to avoid repeated property access

### Technical Details

Firefox's Xray vision wraps objects that cross security boundaries to prevent content scripts from accessing privileged properties. Even after using `structuredClone()` in the content script, when the object is passed via `CustomEvent.detail` to the main world, Firefox wraps it again. By passing data as a JSON string, we completely avoid this issue since strings are primitive values and not subject to Xray wrapping.

## Testing

- ✅ Tested on Firefox with the extension
- ✅ Rectangle creation via MCP server now works without errors
- ✅ No more "Permission denied" errors in console
- ✅ All event properties are accessible after JSON parsing

## Additional Changes

- Added Node.js engine requirement (`>=23.0.0`) to `package.json`
- Improved script injection method in content script for better CSP compliance

## Related

This fix is specifically for Firefox compatibility. Chrome/Edge should continue to work as before since they don't use Xray vision.